### PR TITLE
feature: api/v1/moderation Body 명세 수정#55

### DIFF
--- a/clova_server.py
+++ b/clova_server.py
@@ -30,13 +30,13 @@ class ServerStatus(str, Enum):
     ERROR = "Error"
 
 class VoteContent(BaseModel):
-    voteContent: str = Field(..., description="검열할 투표 내용")
+    content: str = Field(..., description="검열할 투표 내용")
     
-    @field_validator('voteContent')
+    @field_validator('content')
     @classmethod
     def validate_vote_content(cls, v: str) -> str:
         if not v or not v.strip():
-            raise ValueError("voteContent must not be null, empty, or whitespace only.")
+            raise ValueError("content must not be null, empty, or whitespace only.")
         return v.strip()
 
 class APIResponse(BaseModel):
@@ -271,7 +271,7 @@ async def check_vote_content(vote: VoteContent, request: Request):
         "timestamp": timestamp,
         "endpoint": "/api/v1/moderation",
         "client_ip": client_ip,
-        "voteContent": vote.voteContent
+        "voteContent": vote.content
     }
     if not model:
         log_data = {**req_info, "status_code": 500, "moderation_result": None, "error_message": "Moderation system is not initialized"}

--- a/src/ai/ai_process.py
+++ b/src/ai/ai_process.py
@@ -178,7 +178,7 @@ def run_model_process(stop_event: Event, moderation_queue: Queue):
     while not stop_event.is_set():
         if not moderation_queue.empty():
             moderation_request: ModerationRequest = moderation_queue.get()
-            voteContent = moderation_request.voteContent
+            content = moderation_request.content
             request_id = str(moderation_request.voteId)
 
             try:
@@ -186,11 +186,11 @@ def run_model_process(stop_event: Event, moderation_queue: Queue):
                            extra={
                                "section": "moderation", 
                                "request_id": request_id,
-                               "content": voteContent
+                               "content": content
                             })
                 
                 # RAG를 통해 관련 컨텍스트 검색
-                relevant_context = get_relevant_context(voteContent)
+                relevant_context = get_relevant_context(content)
                 
                 # 채팅 형식으로 입력 구성
                 chat = [
@@ -206,7 +206,7 @@ def run_model_process(stop_event: Event, moderation_queue: Queue):
                 
                 chat.append({
                     "role": "user",
-                    "content": f"다음 텍스트가 부적절한지 판단하고 카테고리를 분류해주세요: {voteContent}"
+                    "content": f"다음 텍스트가 부적절한지 판단하고 카테고리를 분류해주세요: {content}"
                 })
                 
                 start_time = time.time()

--- a/src/api/controllers/moderation_controller.py
+++ b/src/api/controllers/moderation_controller.py
@@ -22,11 +22,11 @@ def get_router(moderation_queue, logger=None):
                    extra={
                        "section": "server", 
                        "request_id": request_id,
-                       "content": request.voteContent
+                       "content": request.content
                    })
         
-        if not request.voteContent.strip():
-            error_message = "voteContent must not be null, empty, or whitespace only."
+        if not request.content.strip():
+            error_message = "content must not be null, empty, or whitespace only."
             logger.error(f"잘못된 요청: {error_message}", 
                         extra={"section": "server", "request_id": request_id})
             return JSONResponse(
@@ -44,7 +44,7 @@ def get_router(moderation_queue, logger=None):
                        extra={"section": "server", "request_id": request_id})
             return {
                 "status": "Accepted",
-                "message": "voteContent has been queued",
+                "message": "content has been queued",
                 "data": None
             }
         except Exception as e:

--- a/src/api/dtos/moderation_request.py
+++ b/src/api/dtos/moderation_request.py
@@ -2,4 +2,4 @@ from pydantic import BaseModel
 
 class ModerationRequest(BaseModel):
     voteId: int
-    voteContent: str
+    content: str


### PR DESCRIPTION
필드명 'voteContent'를 'content'로 변경하여 Backend 연동 수정

- 클라이언트 요청 필드명을 'voteContent'에서 'content'로 변경했습니다
- 다음 파일에서 관련 필드명 수정:
  1. clova_server.py:
     - Pydantic VoteContent 모델 필드명 변경
     - 필드 validator 수정
     - API 엔드포인트에서 필드 참조 방식 변경

  2. src/ai/ai_process.py:
     - ModerationRequest에서 필드 참조 수정
     - 로깅 및 RAG 검색 관련 코드에서 필드명 업데이트
     - 모델 프롬프트 생성 코드 수정

  3. src/api/controllers/moderation_controller.py:
     - 요청 로깅 코드에서 필드 접근 방식 변경
     - 유효성 검사 코드의 필드명 및 오류 메시지 수정
     - 응답 메시지 업데이트

  4. src/api/dtos/moderation_request.py:
     - ModerationRequest Pydantic 모델 필드명 변경