### PR TITLE
feat: 로그 포맷터 형식 변경#59

### DIFF
--- a/src/common/logger_config.py
+++ b/src/common/logger_config.py
@@ -128,6 +128,24 @@ class EmailHandler(logging.Handler):
         pass
 
 
+class SafeExtraFormatter(logging.Formatter):
+    """필수 extra 필드가 없을 때 기본값을 채워주는 포맷터"""
+    def format(self, record):
+        # 누락된 필드에 기본값 할당
+        for field, default in [
+            ("section", "-"),
+            ("request_id", "-"),
+            ("content_hash", "-"),
+            ("user_id", "-"),
+            ("pred_label", "-"),
+            ("pred_score", "-"),
+            ("model_version", "-")
+        ]:
+            if not hasattr(record, field):
+                setattr(record, field, default)
+        return super().format(record)
+
+
 # 글로벌 큐 리스너 참조
 _queue_listeners = {}
 
@@ -178,7 +196,7 @@ def init_process_logging(proc: str = "ai") -> logging.Logger:
         encoding="utf-8"
     )
     moderation_handler.setLevel(logging.INFO)
-    moderation_handler.setFormatter(logging.Formatter(
+    moderation_handler.setFormatter(SafeExtraFormatter(
         '%(asctime)s,%(levelname)s,%(section)s,%(request_id)s,%(content_hash)s,%(message)s'
     ))
     
@@ -195,20 +213,20 @@ def init_process_logging(proc: str = "ai") -> logging.Logger:
         encoding="utf-8"
     )
     error_handler.setLevel(logging.ERROR)
-    error_handler.setFormatter(logging.Formatter(
+    error_handler.setFormatter(SafeExtraFormatter(
         '%(asctime)s [%(levelname)s] %(section)s:%(request_id)s - %(message)s'
     ))
     
     # 이메일 알림 핸들러 (오류 발생 시)
     email_handler = EmailHandler(level=logging.ERROR)
-    email_handler.setFormatter(logging.Formatter(
+    email_handler.setFormatter(SafeExtraFormatter(
         '[%(levelname)s] %(section)s:%(request_id)s - %(message)s'
     ))
     
     # 콘솔 핸들러 (개발/디버깅용)
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.INFO)
-    console_handler.setFormatter(logging.Formatter(
+    console_handler.setFormatter(SafeExtraFormatter(
         '%(asctime)s [%(levelname)s] %(section)s:%(request_id)s - %(message)s'
     ))
     


### PR DESCRIPTION
#### 주요 변경 사항
- 로그 포맷 문자열에 %(section)s, %(request_id)s, %(content_hash)s 등 필드가 없을 때 KeyError가 발생하는 문제를 해결하기 위해 SafeExtraFormatter 클래스를 추가
- moderation.log, error.log, email, 콘솔 핸들러의 Formatter를 SafeExtraFormatter로 교체하여, 외부 라이브러리 로그 등 extra 필드가 없는 로그도 기록

#### 상세 내역
- SafeExtraFormatter는 로그 레코드에 필수 필드가 없을 경우 자동으로 기본값(\"-\")을 할당
- 기존 logging.Formatter를 사용하던 부분을 SafeExtraFormatter로 모두 교체
- extra 필드가 누락된 로그에서 KeyError/ValueError가 발생하지 않도록 수정

#### 적용 효과
- 로그 시스템의 안정성 향상 (KeyError로 인한 로그 누락/에러 방지)
- 운영 환경에서의 예기치 않은 로깅 중단 현상 예방
