### PR TITLE
feat: 검열 결과 파싱 오류: 모델 응답과 카테고리 불일치 현상#62

### DIFF
--- a/src/ai/ai_process.py
+++ b/src/ai/ai_process.py
@@ -299,16 +299,13 @@ def run_model_process(stop_event: Event, moderation_queue: Queue):
                         found_category_kr = "기타"  # 기본값 (한국어)
                         reason_detail = ""
                         
-                        # "검열 필요: [카테고리] [이유]" 형식 처리
+                        # 모델 응답에서 카테고리와 이유 분리 (콜론 앞: 카테고리, 콜론 뒤: 이유)
                         if ": " in result:
-                            content_part = result.split(": ", 1)[1]
-                            
+                            category_part, reason_detail = result.split(": ", 1)
                             for category in kr_categories:
-                                if category in content_part:
+                                if category in category_part:
                                     found_category_kr = category
-                                    reason_detail = content_part.replace(category, "", 1).strip()
                                     break
-                            
                             # 이유가 없을 경우 기본 메시지 설정
                             if not reason_detail:
                                 reason_detail = "부적절한 내용이 감지되었습니다."
@@ -318,11 +315,9 @@ def run_model_process(stop_event: Event, moderation_queue: Queue):
                                 if category in result:
                                     found_category_kr = category
                                     break
-                            
                             # 카테고리 외의 내용은 상세 이유로
                             for category in kr_categories:
                                 result = result.replace(category, "", 1)
-                            
                             reason_detail = result.strip()
                             if not reason_detail:
                                 reason_detail = "부적절한 내용이 감지되었습니다."


### PR DESCRIPTION
### 주요 변경 사항

#### 1. 모델 응답 파싱 로직 개선
- 기존:  
  모델 응답에서 카테고리(예: '욕설/비방')와 이유를 분리할 때,  
  콜론(:) 뒤(이유 부분)에서만 카테고리 키워드를 탐색하여 매칭함.
- 문제점:  
  모델이 '욕설/비방: ...'처럼 콜론 앞에 카테고리를 반환할 경우,  
  카테고리 매칭이 실패하여 항상 '기타(OTHER)'로 분류되는 현상 발생.
- 변경 후:  
  콜론(:)이 포함된 응답의 경우,  
  - 콜론 앞 부분(category_part)에서 카테고리 키워드를 탐색하여 올바르게 매칭  
  - 콜론 뒤(reason_detail)는 상세 사유로 사용  
  - 카테고리가 없거나 이유가 비어있으면 기존과 동일하게 기본값 처리

#### 2. 코드 가독성 및 안정성 향상
- 카테고리와 이유 분리 로직을 명확하게 분리하여,  
  향후 모델 응답 포맷이 바뀌어도 유지보수가 쉬워짐

---

### 적용 효과

- 모델이 '카테고리: 이유' 형태로 응답할 때,  
  카테고리가 올바르게 매핑되어 검열 결과(reason)가 정확하게 반환됨
- '기타(OTHER)'로 잘못 분류되는 문제 해결

---

### 예시

- **변경 전:**  
  모델 응답: '욕설/비방: 성적으로 암시적인 내용과 외설적인 표현이 포함되어 있어 부적절합니다.'  
  → 검열 결과: reason='OTHER', reasonDetail='부적절한 내용이 감지되었습니다.'

- **변경 후:**  
  모델 응답: '욕설/비방: 성적으로 암시적인 내용과 외설적인 표현이 포함되어 있어 부적절합니다.'  
  → 검열 결과: reason='OFFENSIVE_LANGUAGE', reasonDetail='성적으로 암시적인 내용과 외설적인 표현이 포함되어 있어 부적절합니다.'

