### PR TITLE
feat: Prometheus 모니터링 도입을 위한 Instrumentator 설정#107

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -478,6 +478,6 @@ zipp==3.21.0
     # via importlib-metadata
 zstandard==0.23.0
     # via langsmith
-
+prometheus-fastapi-instrumentator==7.0.2
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/src/api/api_process.py
+++ b/src/api/api_process.py
@@ -6,6 +6,12 @@ from src.api.controllers.moderation_controller import get_router
 from src.api.controllers.status_controller import status_router
 from src.common.logger_config import init_process_logging, shutdown_logging
 import datetime
+from prometheus_fastapi_instrumentator import Instrumentator
+from prometheus_fastapi_instrumentator.metrics import (
+    request_size,
+    response_size,
+    latency
+)
 
 def run_fastapi_process(moderation_queue: Queue):
     # API 로거 초기화
@@ -25,6 +31,18 @@ def run_fastapi_process(moderation_queue: Queue):
     # 라우터 설정
     app.include_router(get_router(moderation_queue, logger))
     app.include_router(status_router)
+    
+    # Prometheus Instrumentator 설정 (고급 메트릭 포함)
+    instrumentator = Instrumentator(
+        should_group_status_codes=False,   # 2xx/4xx 묶지 않고 분리
+        should_ignore_untemplated=False,   # 라우터 파라미터 포함한 경로도 포함
+        should_respect_env_var=False,      # 환경 변수 무시
+        excluded_handlers=["/metrics"],    # /metrics 는 제외
+    )
+    instrumentator.add(latency())              # 요청 지연 시간
+    instrumentator.add(request_size())    # 요청 사이즈
+    instrumentator.add(response_size())   # 응답 사이즈
+    instrumentator.instrument(app).expose(app)
     
     logger.info("API 서버 시작 준비 완료", extra={"section": "server", "request_id": "init"})
     print(f"{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S,%f')[:-3]} [INFO] server:init - API 서버 시작 준비 완료")


### PR DESCRIPTION
### 주요 변경사항

1. **Prometheus 메트릭 수집 기능 도입**
   - FastAPI 서버에 `prometheus_fastapi_instrumentator`를 적용하여, `/metrics` 엔드포인트에서 API 성능 및 상태 모니터링 가능
   - 활성화된 메트릭: latency(지연 시간), request_size(요청 크기), response_size(응답 크기)
   - Instrumentator 설정 고급 옵션 적용

2. **의존성 추가**
   - `requirements.txt`에 `prometheus-fastapi-instrumentator==7.0.2` 추가

3. **코드 안정성 개선**
   - 메트릭 함수명 변경 및 불필요한(inprogress) 메트릭 제거

