### PR TITLE
cicd: Docker CI/CD 파이프라인 구축

### DIFF
--- a/.github/workflows/cicd-docker.yml
+++ b/.github/workflows/cicd-docker.yml
@@ -1,0 +1,102 @@
+name: FastAPI Docker CI/CD - Tag Trigger
+
+on:
+  push:
+    branches:
+      - cicd/**
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout Repository
+        uses: actions/checkout@v3
+
+      - name: DockerHub Login
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+
+      - name: Extract Tag & Set Image Name
+        id: tagger
+        run: |
+          REF=${GITHUB_REF##*/}
+          COMMIT_SHA=${GITHUB_SHA}
+          IMAGE_NAME="4moa/moa-ai"
+          TAG=""
+
+          if [[ "$GITHUB_REF" =~ ^refs/heads/cicd/.*$ ]]; then
+            TAG="${COMMIT_SHA::7}"
+          elif [[ "$GITHUB_REF" =~ ^refs/tags/v.*$ ]]; then
+            TAG="$REF"
+          else
+            echo "❌ Not a deployable ref: $GITHUB_REF"
+            exit 1
+          fi
+
+          echo "::notice ::GITHUB_REF=$GITHUB_REF"
+          echo "::notice ::TAG=$TAG"
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag
+        run: |
+          if [ -z "${{ steps.tagger.outputs.tag }}" ]; then
+            echo "❌ TAG is empty. Stopping."
+            exit 1
+          fi
+
+      - name: Build & Push Docker Image
+        run: |
+          docker build -t ${{ steps.tagger.outputs.image_name }}:${{ steps.tagger.outputs.tag }} .
+          docker push ${{ steps.tagger.outputs.image_name }}:${{ steps.tagger.outputs.tag }}
+
+      - name: Save SSH Key
+        run: |
+          echo "${{ secrets.GCP_CICD_SSH_KEY }}" > key.pem
+          chmod 600 key.pem
+
+      - name: Debug Tag Info
+        run: |
+          echo "Image to run: ${{ steps.tagger.outputs.image_name }}:${{ steps.tagger.outputs.tag }}"
+
+      - name: Deploy to GCP AI Server
+        env:
+          IMAGE_NAME: ${{ steps.tagger.outputs.image_name }}
+          IMAGE_TAG: ${{ steps.tagger.outputs.tag }}
+        run: |
+          ssh -i key.pem -o StrictHostKeyChecking=no cicd@${{ secrets.GCP_AI_HOST }} <<EOF
+            set -e
+
+            echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+            docker stop moa-ai || true
+            docker rm -f moa-ai || true
+            docker image prune -af --filter "until=48h" || true
+
+            docker pull ${{ steps.tagger.outputs.image_name }}:${{ steps.tagger.outputs.tag }}
+
+            echo "Generating .env file"
+            cat <<EENV | sudo tee /home/cicd/.env > /dev/null
+          ENVIRONMENT=${{ secrets.ENVIRONMENT }}
+          BE_SERVER_IP=${{ secrets.BE_SERVER_IP }}
+          BE_SERVER_PORT=${{ secrets.BE_SERVER_PORT }}
+          HF_TOKEN=${{ secrets.HF_TOKEN }}
+          OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
+          EENV
+
+            sudo chmod 600 /home/cicd/.env
+            sudo chown cicd:cicd /home/cicd/.env
+
+            docker run -d --name moa-ai \
+              --restart unless-stopped \
+              --gpus all \
+              -p 8000:8000 \
+              --env-file /home/cicd/.env \
+              ${{ steps.tagger.outputs.image_name }}:${{ steps.tagger.outputs.tag }}
+
+            docker ps
+            docker cp ./RAG_data.docx moa-ai:/app
+          EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+
+RUN apt-get update && apt-get install -y \
+    python3 python3-pip git ffmpeg libsm6 libxext6 wget curl && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN mkdir -p /app/logs
+
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 8000
+
+CMD ["python3", "app.py"]


### PR DESCRIPTION
## 개요
Dockerfile 작성과 Docker CI/CD 파이프라인을 구축 및 배포 테스트 완료했습니다. 

## 변경 내용
- `.github/workflows/cicd-docker.yml`, `Dockerfile` 추가
  - 대상 브랜치: `cicd/**`, `버전 태그가 지정된 main`

## 적용 배경
- 현재 수동 배포 방식을 개선하고, 커밋과 버전 태그 기준으로 도커 이미지를 관리하기 위해 CI/CD 파이프라인을 도입했습니다. 
- 이전 빅뱅배포 방식이나 현재 수동배포 방식의 배포 시간이 길어, 배포 시간을 줄이기 위해 도입했습니다. 
  - CI/CD 워크플로우 실행 시 10분 이내 배포 완료

## 참고
- main에 머지되어도, 버저닝 태그가 없으면 파이프라인이 동작하지 않음
  - prod 배포 시 클라우드 팀에서 release, hotfix 브랜치의 버전을 참고해 수동 지정할 예정