### PR TITLE
cicd: 버전 추출 및 자동 태그 지정

### DIFF
--- a/.github/workflows/cicd-docker.yml
+++ b/.github/workflows/cicd-docker.yml
@@ -3,9 +3,7 @@ name: FastAPI Docker CI/CD - Tag Trigger
 on:
   push:
     branches:
-      - cicd/**
-    tags:
-      - 'v*'
+      - main
 
 jobs:
   build-and-deploy:
@@ -14,6 +12,42 @@ jobs:
     steps:
       - name: checkout Repository
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Extract Version
+        id: version
+        run: |
+          VERSION=$(grep 'version *= *"v' src/ai/moderation_llm.py | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "Extracted version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Setup Git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      
+
+      - name: Set remote URL with PAT
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          git remote set-url origin https://x-access-token:${GH_PAT}@github.com/${{ github.repository }}
+          git fetch --tags
+
+      - name: Create Git Tag (if not exists)
+        if: github.ref_name == 'main'
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          TAG=${{ steps.version.outputs.version }}
+          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "✅ Tag $TAG already exists"
+          else
+            git tag $TAG
+            git push origin $TAG
+            echo "✅ Created Git tag: $TAG"
+          fi
 
       - name: DockerHub Login
         run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
@@ -26,10 +60,8 @@ jobs:
           IMAGE_NAME="4moa/moa-ai"
           TAG=""
 
-          if [[ "$GITHUB_REF" =~ ^refs/heads/cicd/.*$ ]]; then
-            TAG="${COMMIT_SHA::7}"
-          elif [[ "$GITHUB_REF" =~ ^refs/tags/v.*$ ]]; then
-            TAG="$REF"
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            TAG="${{ steps.version.outputs.version }}"
           else
             echo "❌ Not a deployable ref: $GITHUB_REF"
             exit 1


### PR DESCRIPTION
## 관련 이슈

* 클라우드 # 116

## 작업 개요

* 기존 CI/CD 버전 트리거 삭제 및 자동 버저닝 기능 추가

## 작업 상세

1. CI/CD 트리거 변경

   * v로 시작하는 버전 태그 트리거 삭제, main 브랜치 트리거로 변경

2. 태그 자동 지정

   * src/ai/moderation_llm.py 파일 내 명시된 버전을 Git / Docker tag로 지정
     (버전 앞에 v 필수로 붙여 주셔야 합니다.)

## 테스트

* [x] main 트리거 정상 동작 확인 (Docker image tag: vX.Y.Z)
* [x] !main 트리거 정상 동작 확인 (Docker image tag: 커밋ID)
