### PR TITLE
cicd: 버전 추출 위치 수정

### DIFF
--- a/.github/workflows/cicd-docker.yml
+++ b/.github/workflows/cicd-docker.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Extract Version
         id: version
         run: |
-          VERSION=$(grep 'version *= *"v' src/ai/moderation_llm.py | sed -E 's/.*"([^"]+)".*/\1/')
+          VERSION=$(grep '__version__ *= *"v' src/version.py | sed -E 's/.*"([^"]+)".*/\1/')
           echo "Extracted version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## 작업 개요

* 기존 CI/CD 버전 추출 위치 수정 (src/ai/moderation_llm.py → src/version.py)

## 작업 상세

1. 태그 자동 지정

   * src/version.py 파일 내 명시된 버전을 Git / Docker tag로 지정
     (버전 앞에 v 필수로 붙여 주셔야 합니다.)