### PR TITLE
cicd: 시크릿 추가 주입 및 decord 버전 변경

### DIFF
--- a/.github/workflows/cicd-docker.yml
+++ b/.github/workflows/cicd-docker.yml
@@ -118,6 +118,7 @@ jobs:
           HF_TOKEN=${{ secrets.HF_TOKEN }}
           OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
           SERPER_API_KEY=${{ secrets.SERPER_API_KEY }}
+          GOOGLE_SEARCH_API_KEY=${{ secrets.GOOGLE_SEARCH_API_KEY }}
           EENV
 
             sudo chmod 600 /home/cicd/.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ dataclasses-json==0.6.7
     # via langchain-community
 
 
-decord==0.6.0
+decord==0.5.2
     # via -r requirements.in
 deprecated==1.2.18
     # via


### PR DESCRIPTION
## 작업 개요

* GOOGLE_SEARCH_API_KEY 시크릿 주입 단계 추가
* docker build를 위한 decord 버전 변경

## 작업 상세

1. docker build를 위한 decord 버전 변경

   * 기존 0.6.0 버전으로 Docker build가 되지 않아 docker에서 직접 사용 가능한 0.5.2 버전으로 다운그레이드 했습니다. 