### PR TITLE
feat: 모델 투표 결과 데이터에서 version 필드 제거#138

### DIFF
--- a/src/ai/vote_generator.py
+++ b/src/ai/vote_generator.py
@@ -56,6 +56,5 @@ class VoteGenerator:
             "imageUrl": "",
             "imageName": "",
             "openAt": open_at,
-            "closedAt": closed_at,
-            "version": MODEL_VERSION
+            "closedAt": closed_at
         }

--- a/src/api/dtos/model_vote_request.py
+++ b/src/api/dtos/model_vote_request.py
@@ -7,4 +7,3 @@ class ModelVoteRequest(BaseModel):
     imageName: str = ""
     openAt: str
     closedAt: str
-    version: str

--- a/src/integrations/delivery.py
+++ b/src/integrations/delivery.py
@@ -18,8 +18,7 @@ class Delivery:
             imageUrl=vote.get("imageUrl", ""),
             imageName=vote.get("imageName", ""),
             openAt=vote.get("openAt", ""),
-            closedAt=vote.get("closedAt", ""),
-            version=vote.get("version", "")
+            closedAt=vote.get("closedAt", "")
         )
         headers = {"Content-Type": "application/json"}
         logger.info(f"모델 투표 결과 전송 시작", extra={"section": "server", "request_id": request_id, "word_id": word_id})


### PR DESCRIPTION
### 주요 변경사항 요약

1. **모델 투표 결과에서 version 필드 제거**
   - 모델이 생성한 투표 결과(`VoteGenerator.generate`)의 반환 dict에서 version 필드(`"version": MODEL_VERSION`)를 삭제
   - BE로 전송하는 데이터(`ModelVoteRequest`)에서 version 필드를 완전히 제거.

2. **DTO 및 전달 로직 정리**
   - `ModelVoteRequest`(Pydantic DTO)에서 version 필드 정의를 삭제
   - `Delivery.send_model_vote`에서 version 파라미터를 더 이상 사용하지 않도록 수정

3. **불필요 필드 제거로 인한 구조 단순화**
   - 모델 투표 생성->전달->수신까지 version 필드가 포함되지 않으므로, BE와의 데이터 구조가 더 명확짐
