### PR TITLE
bugfix: VoteGenerator 동시성 제어 도입: 락(Lock) 메커니즘 적용#147

### DIFF
--- a/tests/dummy_server.py
+++ b/tests/dummy_server.py
@@ -33,7 +33,7 @@ def run_dummy_server_process():
         return {
             "message": "SUCCESS",
             "data": {
-                "wordId": vote.wordId,
+                "content": vote.content,
                 "stored": True
             }
         }


### PR DESCRIPTION
### 주요 변경사항 요약

#### 1. Vote 생성~검열~전송 구간 상호배제(Mutual Exclusion) 락 적용
- src/ai/ai_process.py
  - threading.Lock를 도입하여 vote 생성, 검열, 전송 전체 과정을 한 번에 하나의 요청만 처리하도록 변경
  - 여러 요청이 동시에 들어와도 vote 처리 구간에서 순차적으로 안전하게 처리됨
  - 락 적용 구간: `run_model_process` 함수 내 `task_type == "vote"` 블록 전체

#### 2. 테스트 서버 응답 필드명 수정
- tests/dummy_server.py
  - POST /api/v1/ai/votes 응답에서 data의 key를 `"wordId"` → `"content"`로 변경
  - 실제 vote 객체의 wordId가 아닌 content 값을 반환하도록 수정