### PR TITLE
feat: 키워드 사이트 위한 CORS 설정#167

### DIFF
--- a/src/api/api_process.py
+++ b/src/api/api_process.py
@@ -1,6 +1,7 @@
 from multiprocessing import Queue
 from multiprocessing.synchronize import Event
 from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 from src.api.controllers.analysis_controller import get_analyzer_router
 from src.api.controllers.moderation_controller import get_router
@@ -41,6 +42,15 @@ def run_fastapi_process(moderation_task_queue: Queue, result_queue: Queue):
             return response
 
     app.add_middleware(InProgressMiddleware)
+
+    # CORS 설정
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],  # 정적 배포 후, * 대신 도메인 주소 입력
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
     # 로거를 FastAPI 앱 상태에 저장하여 컨트롤러에서 접근 가능하게 함
     app.state.logger = logger


### PR DESCRIPTION
### 상세 변경사항

#### 1. Import 추가
```python
from fastapi.middleware.cors import CORSMiddleware
```

#### 2. CORS 미들웨어 설정 추가
```python
# CORS 설정
app.add_middleware(
    CORSMiddleware,
    allow_origins=["*"],  # 정적 배포 후, * 대신 도메인 주소 입력
    allow_credentials=True,
    allow_methods=["*"],
    allow_headers=["*"],
)
```

### 변경 목적
- 키워드 사이트에서 AI 서버 API에 접근할 수 있도록 CORS 설정 추가

### 설정 내용
- **allow_origins**: 모든 origin 허용 (`["*"]`)
- **allow_credentials**: 인증 정보 포함 요청 허용
- **allow_methods**: 모든 HTTP 메서드 허용
- **allow_headers**: 모든 헤더 허용

###  참고사항
- 현재는 개발 환경을 위해 모든 origin을 허용하도록 설정
- 정적 배포 후에는 보안을 위해 특정 도메인 주소로 변경 예정

